### PR TITLE
Drop visualization deps and publish to PYPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,6 @@ setup(
     install_requires=[
         "sqlparse>=0.3.1",
         "networkx>=2.4",
-        "flask",
-        "flask_cors",
-        "werkzeug",
     ],
     entry_points={"console_scripts": ["sqllineage = sqllineage.cli:main"]},
     extras_require={
@@ -90,6 +87,10 @@ setup(
             "wheel",
         ],
         "docs": ["Sphinx>=3.2.0", "sphinx_rtd_theme>=0.5.0"],
+        "cli": [
+            "flask",
+            "flask_cors",
+            "werkzeug",
+        ],
     },
-    cmdclass={"egg_info": EggInfoWithJS},
 )

--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -40,7 +40,7 @@ def _monkey_patch() -> None:
 
 _monkey_patch()
 
-NAME = "sqllineage"
+NAME = "metaphor-sqllineage"
 VERSION = "1.3.6"
 DEFAULT_LOGGING = {
     "version": 1,

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -7,7 +7,10 @@ from sqlparse.sql import Statement
 from sqllineage.core import LineageAnalyzer
 from sqllineage.core.holders import SQLLineageHolder
 from sqllineage.core.models import Column, Table
-from sqllineage.drawing import draw_lineage_graph
+try:
+    from sqllineage.drawing import draw_lineage_graph
+except:
+    pass
 from sqllineage.io import to_cytoscape
 from sqllineage.utils.constant import LineageLevel
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Move visualization deps to optional to reduce package size.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Only change the package name, should be the drop-in version of sqllineage
- try import `sqllineage.drawing` and suppress the import error


<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->


### 🧪 Tested?

Test local built package.

```
from sqllineage.runner import LineageRunner
parser = LineageRunner("...")
```

<!--
  Describe how the change was tested. This includes
    - Before/after screenshots of the change 
    - Video recording of the change in user workflow
    - Console output of CLI commands
    - URL demonstrating the actual change
    - Unit tests, if that alone is sufficient
    - N/A, if no test is applicable/possible
-->
