### PR TITLE
add schema fetcher to resolve columns in [sc-15622]

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.1"
+VERSION = "2.0.2"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -10,6 +10,7 @@ from sqllineage.core.models import Column, Table, TableMetadata
 from sqllineage.drawing import draw_lineage_graph
 from sqllineage.io import to_cytoscape
 from sqllineage.utils.constant import LineageLevel
+from sqllineage.utils.schemaFetcher import SchemaFetcher
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ class LineageRunner(object):
         sql: str,
         default_database: Optional[str] = None,
         default_schema: Optional[str] = None,
+        schema_fetcher: Optional[SchemaFetcher] = None,
         encoding: Optional[str] = None,
         verbose: bool = False,
         draw_options: Optional[Dict[str, str]] = None,
@@ -51,6 +53,7 @@ class LineageRunner(object):
         self._metadata = TableMetadata(
             default_database=default_database.lower() if default_database else None,
             default_schema=default_schema.lower() if default_schema else None,
+            schema_fetcher=schema_fetcher,
         )
         self._draw_options = draw_options if draw_options else {}
         self._evaluated = False

--- a/sqllineage/utils/helpers.py
+++ b/sqllineage/utils/helpers.py
@@ -1,5 +1,6 @@
 import logging
 from argparse import Namespace
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -27,3 +28,17 @@ def extract_sql_from_args(args: Namespace) -> str:
     elif getattr(args, "e", None):
         sql = args.e
     return sql
+
+
+def table_fullname(
+    table: str, default_database: Optional[str], default_schema: Optional[str]
+) -> str:
+    dots = table.count(".")
+    if dots == 0:
+        if default_database and default_schema:
+            return f"{default_database}.{default_schema}.{table}".lower()
+    elif dots == 1:
+        if default_database:
+            return f"{default_database}.{table}".lower()
+    else:
+        return table.lower()

--- a/sqllineage/utils/helpers.py
+++ b/sqllineage/utils/helpers.py
@@ -33,6 +33,10 @@ def extract_sql_from_args(args: Namespace) -> str:
 def table_fullname(
     table: str, default_database: Optional[str], default_schema: Optional[str]
 ) -> str:
+    """
+    Best effort to assemble the table fullname and normalize to lowercase
+    If missing database or schema, return the input table name
+    """
     dots = table.count(".")
     if dots == 0:
         if default_database and default_schema:
@@ -40,5 +44,5 @@ def table_fullname(
     elif dots == 1:
         if default_database:
             return f"{default_database}.{table}".lower()
-    else:
-        return table.lower()
+
+    return table.lower()

--- a/sqllineage/utils/schemaFetcher.py
+++ b/sqllineage/utils/schemaFetcher.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, Optional
+
+
+class SchemaFetcher:
+    """
+    This class provides capability to fetch the schema (columns) of a given table
+    """
+
+    def get_schema(
+        self, table: str, platform: Optional[str] = None, account: Optional[str] = None
+    ) -> List[str]:
+        """
+        get the column names of the table
+        """
+        raise NotImplementedError
+
+
+class DummySchemaFetcher(SchemaFetcher):
+    """
+    Dummy schema fetch that uses pre-defined schemas
+    """
+
+    def __init__(self, tableSchemas: Dict[str, List[str]]) -> None:
+        self._schemas = tableSchemas
+
+    def get_schema(
+        self, table: str, platform: Optional[str] = None, account: Optional[str] = None
+    ) -> List[str]:
+        return self._schemas.get(table, [])

--- a/sqllineagejs/package.json
+++ b/sqllineagejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqllineagejs",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.2",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,7 +26,14 @@ def assert_table_lineage_equal(
         ), f"\n\tExpected {_type} Table: {expected}\n\tActual {_type} Table: {actual}"
 
 
-def assert_column_lineage_equal(sql, column_lineages=None, exclude_subquery=True):
+def assert_column_lineage_equal(
+    sql,
+    column_lineages=None,
+    exclude_subquery=True,
+    default_database=None,
+    default_schema=None,
+    schema_fetcher=None,
+):
     expected = set()
     if column_lineages:
         for src, tgt in column_lineages:
@@ -36,7 +43,8 @@ def assert_column_lineage_equal(sql, column_lineages=None, exclude_subquery=True
             tgt_col = Column(tgt.column)
             tgt_col.parent = Table(tgt.qualifier)
             expected.add((src_col, tgt_col))
-    lr = LineageRunner(sql)
+
+    lr = LineageRunner(sql, default_database, default_schema, schema_fetcher)
     actual = {
         (lineage[0], lineage[-1])
         for lineage in set(lr.get_column_lineage(exclude_subquery))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,9 @@
 import pytest
 from sqlparse.sql import Parenthesis
 
-from sqllineage.core.models import Column, Path, Schema, SubQuery, Table
+from sqllineage.core.models import Column, Path, Schema, SubQuery, Table, TableMetadata
 from sqllineage.exceptions import SQLLineageException
+from sqllineage.utils.schemaFetcher import DummySchemaFetcher
 
 
 def test_repr_dummy():
@@ -23,3 +24,17 @@ def test_hash_eq():
     assert len({Schema("a"), Schema("a")}) == 1
     assert Table("a") == Table("a")
     assert len({Table("a"), Table("a")}) == 1
+
+
+def test_table_metadata():
+    metadata = TableMetadata(
+        default_database="db",
+        default_schema="sch",
+        platform="SNOWFLAKE",
+        account="act",
+        schema_fetcher=DummySchemaFetcher({"db.sch.tab1": ["foo", "bar"]}),
+    )
+    assert metadata.get_schema("tab1") == ["foo", "bar"]
+    assert metadata.get_schema("db.sch.tab1") == ["foo", "bar"]
+    assert metadata.get_schema("sch.tab1") == ["foo", "bar"]
+    assert metadata.get_schema("tab2") == []


### PR DESCRIPTION
Add schema fetcher into CLL resolution

- define schemaFetcher interface
- use schema to determine ambiguous columns

> TODO: 
- resolve `*`: the parser treats `*` as a column, will do refactoring next
- use subquery columns to determine upper-level query columns: columns are not currently stored inside a `SubQuery` object, will need some refactoring