### PR TITLE
update runner interface

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,3 +8,4 @@ warn_no_return=True
 warn_redundant_casts=True
 warn_unused_ignores=True
 disallow_any_generics=True
+exclude=venv

--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.2"
+VERSION = "2.0.3"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -10,7 +10,6 @@ from sqllineage.core.models import Column, Table, TableMetadata
 from sqllineage.drawing import draw_lineage_graph
 from sqllineage.io import to_cytoscape
 from sqllineage.utils.constant import LineageLevel
-from sqllineage.utils.schemaFetcher import SchemaFetcher
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +32,7 @@ class LineageRunner(object):
     def __init__(
         self,
         sql: str,
-        default_database: Optional[str] = None,
-        default_schema: Optional[str] = None,
-        schema_fetcher: Optional[SchemaFetcher] = None,
+        table_metadata: Optional[TableMetadata] = None,
         encoding: Optional[str] = None,
         verbose: bool = False,
         draw_options: Optional[Dict[str, str]] = None,
@@ -50,11 +47,7 @@ class LineageRunner(object):
         self._encoding = encoding
         self._sql = sql
         self._verbose = verbose
-        self._metadata = TableMetadata(
-            default_database=default_database.lower() if default_database else None,
-            default_schema=default_schema.lower() if default_schema else None,
-            schema_fetcher=schema_fetcher,
-        )
+        self._metadata = table_metadata or TableMetadata()
         self._draw_options = draw_options if draw_options else {}
         self._evaluated = False
         self._stmt: List[Statement] = []

--- a/sqllineagejs/package.json
+++ b/sqllineagejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqllineagejs",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.2",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,4 @@
-from sqllineage.core.models import Column, Table
+from sqllineage.core.models import Column, Table, TableMetadata
 from sqllineage.runner import LineageRunner
 
 
@@ -9,7 +9,10 @@ def assert_table_lineage_equal(
     default_database=None,
     default_schema=None,
 ):
-    lr = LineageRunner(sql, default_database, default_schema)
+    lr = LineageRunner(
+        sql,
+        TableMetadata(default_database=default_database, default_schema=default_schema),
+    )
     for _type, actual, expected in zip(
         ["Source", "Target"],
         [lr.source_tables, lr.target_tables],
@@ -44,7 +47,14 @@ def assert_column_lineage_equal(
             tgt_col.parent = Table(tgt.qualifier)
             expected.add((src_col, tgt_col))
 
-    lr = LineageRunner(sql, default_database, default_schema, schema_fetcher)
+    lr = LineageRunner(
+        sql,
+        TableMetadata(
+            default_database=default_database,
+            default_schema=default_schema,
+            schema_fetcher=schema_fetcher,
+        ),
+    )
     actual = {
         (lineage[0], lineage[-1])
         for lineage in set(lr.get_column_lineage(exclude_subquery))


### PR DESCRIPTION
Update runner interface to take `TableMetadata` object instead of the individual metadata fields. This allows the input of data platform and account, makes the interface cleaner and leave room for more metadata in the future.