### PR TITLE
Fix CLL return value typing

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.3"
+VERSION = "2.0.4"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -143,7 +143,7 @@ Target Tables:
         return sorted(self._sql_holder.intermediate_tables, key=lambda x: str(x))
 
     @lazy_method
-    def get_column_lineage(self, exclude_subquery=True) -> List[Tuple[Column, Column]]:
+    def get_column_lineage(self, exclude_subquery=True) -> List[Tuple[Column, ...]]:
         """
         a list of column tuple :class:`sqllineage.models.Column`
         """


### PR DESCRIPTION
The return value of `get_column_lineage` should be a variable length tuple containing intermediate columns if exists, not just source/target columns. 