### PR TITLE
Improve sqllineage CLL parser [sc-15605]

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.8"
+VERSION = "2.0.9"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/core/handlers/source.py
+++ b/sqllineage/core/handlers/source.py
@@ -47,8 +47,10 @@ class SourceHandler(NextTokenBaseHandler):
         if any(re.match(regex, token.normalized) for regex in self.SOURCE_TABLE_TOKENS):
             self.column_flag = False
             return True
-        elif bool(token.normalized == "SELECT"):
+        elif token.normalized == "SELECT":
             self.column_flag = True
+            return True
+        elif token.normalized == "DISTINCT" and self.column_flag:
             return True
         else:
             return False

--- a/tests/test_tpcds.py
+++ b/tests/test_tpcds.py
@@ -2113,7 +2113,6 @@ expected = {
     ),
     54: (
         {
-            "my_customers",
             "customer_address",
             "web_sales",
             "item",


### PR DESCRIPTION
Fix for the case when there is `DISTINCT` following `SELECT`, previously `DISTINCT` is an unrecognized keyword after `SELECT`, which disables the following column handling.
Also added more test cases for `union` to prove its robustness.

Remaining TPC-DS tests without CLL and reason:
- case 14 and 76: sqlparse doesn't recognize selecting a fixed value as a column name but without keyword `AS`, e.g. `select 'foo' col1`. It treats the column as two separate tokens, which causes the lineage processing to return no result, since it expects only an identifierList after `select`.
- case 54: sqlparse incorrectly tokenized the column `segment` as a keyword, not an identifier.