### PR TITLE
make CTE alias case-insensitive

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.9"
+VERSION = "2.0.10"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/core/handlers/source.py
+++ b/sqllineage/core/handlers/source.py
@@ -156,14 +156,16 @@ class SourceHandler(NextTokenBaseHandler):
                 parenthesis, alias = subqueries[0]
                 read = SubQuery.of(parenthesis, alias)
             else:
-                cte_dict = {s.alias: s for s in holder.cte}
                 if "." not in identifier.value:
-                    cte = cte_dict.get(identifier.get_real_name())
+                    cte_dict = {s.alias: s for s in holder.cte}
+                    cte = cte_dict.get(identifier.get_real_name().lower())
                     if cte is not None:
                         # could reference CTE with or without alias
                         read = SubQuery.of(
                             cte.token,
-                            identifier.get_alias() or identifier.get_real_name(),
+                            (
+                                identifier.get_alias() or identifier.get_real_name()
+                            ).lower(),
                         )
                 if read is None:
                     read = Table.of(identifier, self.table_metadata)

--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -161,7 +161,7 @@ class SubQuery:
         """
         self.token = token
         self._query = token.value
-        self.alias = alias if alias is not None else f"subquery_{hash(self)}"
+        self.alias = alias.lower() if alias is not None else f"subquery_{hash(self)}"
 
     def __str__(self):
         return self.alias

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -745,8 +745,8 @@ SELECT wt.col1 FROM wtab1 wt"""
 
 
 def test_column_reference_from_cte_using_qualifier():
-    sql = """WITH wtab1 AS (SELECT col1 FROM tab2)
-INSERT OVERWRITE TABLE tab1
+    sql = """WITH WTAB1 AS (SELECT col1 FROM tab2)
+INSERT OVERWRITE TABLE TAB1
 SELECT wtab1.col1 FROM wtab1"""
     assert_column_lineage_equal(
         sql,


### PR DESCRIPTION
An CTE can be referenced by its alias in a case-insensitive way, we need to be able to handle it by normalizing the alias to lowercase.