### PR TITLE
CLL parser support nested columns [sc-16860]

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.10"
+VERSION = "2.0.11"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/data/tpcds/query49.sql
+++ b/sqllineage/data/tpcds/query49.sql
@@ -37,10 +37,10 @@ where (
           )
 union
 select 'catalog' as channel
-     , catalog.item
-     , catalog.return_ratio
-     , catalog.return_rank
-     , catalog.currency_rank
+     , catalogs.item
+     , catalogs.return_ratio
+     , catalogs.return_rank
+     , catalogs.currency_rank
 from (
          select item
               , return_ratio
@@ -66,7 +66,7 @@ from (
                  and d_moy = 12
                group by cs.cs_item_sk
               ) in_cat
-     ) catalog
+     ) catalogs
 where (
               catalog.return_rank <= 10
               or

--- a/sqllineage/utils/entities.py
+++ b/sqllineage/utils/entities.py
@@ -11,6 +11,7 @@ class SubQueryTuple(NamedTuple):
 class ColumnQualifierTuple(NamedTuple):
     column: str
     qualifier: Optional[str]
+    fullname: Optional[str] = None
 
 
 class ColumnExpression(NamedTuple):

--- a/tests/test_tpcds.py
+++ b/tests/test_tpcds.py
@@ -1829,7 +1829,7 @@ expected = {
                 ColumnQualifierTuple("currency_rank", "query49"),
             ),
             (
-                ColumnQualifierTuple("return_ratio", "catalog"),
+                ColumnQualifierTuple("cs_quantity", "catalog_sales"),
                 ColumnQualifierTuple("return_ratio", "query49"),
             ),
             (
@@ -1841,7 +1841,7 @@ expected = {
                 ColumnQualifierTuple("currency_rank", "query49"),
             ),
             (
-                ColumnQualifierTuple("item", "catalog"),
+                ColumnQualifierTuple("cs_item_sk", "catalog_sales"),
                 ColumnQualifierTuple("item", "query49"),
             ),
             (
@@ -1853,7 +1853,7 @@ expected = {
                 ColumnQualifierTuple("return_ratio", "query49"),
             ),
             (
-                ColumnQualifierTuple("return_rank", "catalog"),
+                ColumnQualifierTuple("cs_quantity", "catalog_sales"),
                 ColumnQualifierTuple("return_rank", "query49"),
             ),
             (
@@ -1873,7 +1873,7 @@ expected = {
                 ColumnQualifierTuple("item", "query49"),
             ),
             (
-                ColumnQualifierTuple("currency_rank", "catalog"),
+                ColumnQualifierTuple("cs_net_paid", "catalog_sales"),
                 ColumnQualifierTuple("currency_rank", "query49"),
             ),
             (
@@ -1883,6 +1883,18 @@ expected = {
             (
                 ColumnQualifierTuple("wr_return_quantity", "web_returns"),
                 ColumnQualifierTuple("return_rank", "query49"),
+            ),
+            (
+                ColumnQualifierTuple("cr_return_quantity", "catalog_returns"),
+                ColumnQualifierTuple("return_rank", "query49"),
+            ),
+            (
+                ColumnQualifierTuple("cr_return_amount", "catalog_returns"),
+                ColumnQualifierTuple("currency_rank", "query49"),
+            ),
+            (
+                ColumnQualifierTuple("cr_return_quantity", "catalog_returns"),
+                ColumnQualifierTuple("return_ratio", "query49"),
             ),
         ],
         {},


### PR DESCRIPTION
In data systems that supports nested columns in SQL, e.g. BigQuery, nested column reference usually uses the same `.` symbol, which can be confused for table qualifier. e.g. for `SELECT col.status FROM db.dwh.tab1`, `status` here is a sub-column of `col`, but the parser will think `col` is the table or alias, and `status` is the column.

- Make the best effort to match the column token full name to table alias to determine if the first part of the full name is table qualifier. If not match can be found, we treat the column full name as nested column.