### PR TITLE
update sqlparse to 0.4.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "sqlparse>=0.4.3",
+        "sqlparse>=0.4.4",
         "networkx>=2.8",
     ],
     entry_points={"console_scripts": ["sqllineage = sqllineage.cli:main"]},

--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -23,10 +23,10 @@ def _patch_updating_lateral_view_lexeme() -> None:
     from sqlparse.keywords import SQL_REGEX
 
     for i, (regex, lexeme) in enumerate(SQL_REGEX):
-        if regex("LATERAL VIEW EXPLODE(col)"):
+        rgx = re.compile(regex, re.IGNORECASE | re.UNICODE).match
+        if rgx("LATERAL VIEW EXPLODE(col)"):
             new_regex = r"(LATERAL\s+VIEW\s+)(OUTER\s+)?(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK|JSON_TUPLE)\b"
-            new_compile = re.compile(new_regex, re.IGNORECASE | re.UNICODE).match
-            SQL_REGEX[i] = (new_compile, lexeme)
+            SQL_REGEX[i] = (new_regex, lexeme)
             break
 
 
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.12"
+VERSION = "2.0.13"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -4,7 +4,7 @@ from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 from sqlparse import tokens as T
 from sqlparse.engine import grouping
-from sqlparse.keywords import is_keyword
+from sqlparse.lexer import Lexer
 from sqlparse.sql import (
     Case,
     Comparison,
@@ -335,7 +335,11 @@ class Column:
                 isinstance(t, Function) and t.get_real_name() not in FUNC_DTYPE
                 for t in token.tokens
             )
-            is_kw = is_keyword(real_name) if real_name is not None else False
+            is_kw = (
+                Lexer.get_default_instance().is_keyword(real_name)
+                if real_name is not None
+                else False
+            )
             if (
                 # real name is None: col1=1 AS int
                 real_name is None


### PR DESCRIPTION
Sqlparse 0.4.4 fixes a security vulnerability in the parser where a regular expression vulnerable to ReDOS.
https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG

It also introduced some breaking changes that are fixed here.
All existing test cases passed
