### PR TITLE
issue with create table as select with column spec [sc-18391]

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.13"
+VERSION = "2.0.14"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/utils/sqlparse.py
+++ b/sqllineage/utils/sqlparse.py
@@ -144,7 +144,8 @@ def get_subquery_parentheses(
     """
     subquery = []
     as_idx, as_ = token.token_next_by(m=(Keyword, "AS"))
-    # get all token subgroups that does not start with an Identifier, e.g. table name with column definitions "table1 (col1, col2)".
+    # get all token subgroups that does not start with an Identifier,
+    # e.g. table name with column definitions "table1 (col1, col2)".
     sublist = [
         s for s in token.get_sublists() if not isinstance(s.tokens[0], Identifier)
     ]

--- a/sqllineage/utils/sqlparse.py
+++ b/sqllineage/utils/sqlparse.py
@@ -144,7 +144,10 @@ def get_subquery_parentheses(
     """
     subquery = []
     as_idx, as_ = token.token_next_by(m=(Keyword, "AS"))
-    sublist = list(token.get_sublists())
+    # get all token subgroups that does not start with an Identifier, e.g. table name with column definitions "table1 (col1, col2)".
+    sublist = [
+        s for s in token.get_sublists() if not isinstance(s.tokens[0], Identifier)
+    ]
     if as_ is not None and len(sublist) == 1:
         # CTE: tbl AS (SELECT 1)
         target = sublist[0]

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -3,7 +3,6 @@ import pytest
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.entities import ColumnQualifierTuple
 from sqllineage.utils.schemaFetcher import DummySchemaFetcher
-
 from .helpers import assert_column_lineage_equal
 
 

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -3,6 +3,7 @@ import pytest
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.entities import ColumnQualifierTuple
 from sqllineage.utils.schemaFetcher import DummySchemaFetcher
+
 from .helpers import assert_column_lineage_equal
 
 
@@ -1251,6 +1252,30 @@ def test_nested_column():
             (
                 ColumnQualifierTuple("count", "tab2"),
                 ColumnQualifierTuple("tc", "tab1"),
+            ),
+        ],
+    )
+
+
+def test_create_view_with_columns_as_select():
+    sql = """
+    create or replace view t1(id, name) as (
+    with cte as
+        (select id, name from t2)
+    select id, name from cte
+    );
+    """
+
+    assert_column_lineage_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("id", "t2"),
+                ColumnQualifierTuple("id", "t1"),
+            ),
+            (
+                ColumnQualifierTuple("name", "t2"),
+                ColumnQualifierTuple("name", "t1"),
             ),
         ],
     )


### PR DESCRIPTION
Currently the SQL statement like 
```
Create table/view xxx (col1, col2) as select ...
```
is not parsed correctly and has no CLL output, the reason being the `xxx (col1, col2)` is treated as a function and making the `as select` not recognized as a subquery.
Added a check to handle this situation.