### PR TITLE
Lineage Subquery alias issue [sc-18330]

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.14"
+VERSION = "2.0.15"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/sqllineage/core/handlers/source.py
+++ b/sqllineage/core/handlers/source.py
@@ -238,11 +238,7 @@ class SourceHandler(NextTokenBaseHandler):
                 break
 
             for alias in table_alias.keys():
-                if (
-                    fullname.startswith(alias)
-                    and len(fullname) > len(alias)
-                    and fullname[len(alias)] == "."
-                ):
+                if fullname.lower().startswith(f"{alias.lower()}."):
                     column.source_columns[i] = ColumnQualifierTuple(
                         col, alias, fullname
                     )

--- a/sqllineage/utils/sqlparse.py
+++ b/sqllineage/utils/sqlparse.py
@@ -110,8 +110,18 @@ def get_identifier_name_and_parent(identifier: Identifier) -> Tuple[str, Optiona
         start=len(identifier.tokens),
         reverse=True,
     )
-    real_name = identifier._get_first_name(dot_idx, real_name=True)
 
+    if not dot_idx:
+        # if no dot in identifier, could be subquery with alias, e.g. (SELECT ...) as xxx
+        # retrieve the alias as the real name, no parent name
+        subquery = [
+            token for token in identifier.tokens if isinstance(token, Parenthesis)
+        ]
+        alias = [token for token in identifier.tokens if isinstance(token, Identifier)]
+        if len(subquery) == 1 and len(alias) == 1:
+            return alias[0]._get_first_name(real_name=True), None
+
+    real_name = identifier._get_first_name(dot_idx, real_name=True)
     parent_name = (
         "".join(
             [

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1278,3 +1278,31 @@ def test_create_view_with_columns_as_select():
             ),
         ],
     )
+
+
+def test_subquery_with_alias():
+    sql = """
+    create or replace view tab1 as (
+      SELECT DISTINCT
+        A.id,
+        AL.name
+      FROM tab2 AL
+      LEFT JOIN (
+        SELECT id
+        FROM tab3) AS A
+      );
+    """
+
+    assert_column_lineage_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("id", "tab3"),
+                ColumnQualifierTuple("id", "tab1"),
+            ),
+            (
+                ColumnQualifierTuple("name", "tab2"),
+                ColumnQualifierTuple("name", "tab1"),
+            ),
+        ],
+    )


### PR DESCRIPTION
Fix two subquery alias issues:
- alias name not recognized if subquery is followed by `AS xxx`, e.g. `(SELECT ...) AS xxx`.
- column qualifier matching is case sensitive, thus missing certain alias matching if the alias name has been normalized.