### PR TITLE
fix for identifier as keyword

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -43,7 +43,7 @@ def _monkey_patch() -> None:
 _monkey_patch()
 
 NAME = "metaphor-sqllineage"
-VERSION = "2.0.15"
+VERSION = "2.0.16"
 DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1284,13 +1284,14 @@ def test_subquery_with_alias():
     sql = """
     create or replace view tab1 as (
       SELECT DISTINCT
-        A.id,
+        LINK.id,
         AL.name
       FROM tab2 AL
       LEFT JOIN (
         SELECT id
-        FROM tab3) AS A
-      );
+        FROM tab3
+      ) as LINK
+    );
     """
 
     assert_column_lineage_equal(


### PR DESCRIPTION
Sometimes sqlparse incorrectly recognized some identifiers as keywords, need to handle that at least in obvious cases.